### PR TITLE
Add some missing keywords + fix Exit Function

### DIFF
--- a/syntaxes/tests/other.bas
+++ b/syntaxes/tests/other.bas
@@ -132,15 +132,15 @@ End
 Declare PtrSafe Sub First Lib "MyLib" (ByRef a As Any)
 '<------- keyword.other.vba
 '       ^^^^^^^ keyword.other.vba
-'                                                 ^^^ support.type.builtin
+'                                                 ^^^ support.type.builtin.vba
 
 Private WithEvents app As Outlook.Application
 '       ^^^^^^^^^^ keyword.other.vba
 
-Event LogonCompleted(UserName as String) 
+Event LogonCompleted(UserName as String)
 ' <----- keyword.other.vba
- 
-Sub Logon 
-    RaiseEvent LogonCompleted ("AntoineJan") 
+
+Sub Logon
+    RaiseEvent LogonCompleted ("AntoineJan")
 '   ^^^^^^^^^^ keyword.other.vba
 End Sub

--- a/syntaxes/tests/other.bas
+++ b/syntaxes/tests/other.bas
@@ -95,9 +95,52 @@ End With
 ' ^^^^^^^^^^ keyword.conditional.end.vba
 
 ReDim Preserve xArray(1 To 5) As Double
-' <--- storage.modifier.vba
+' <----- storage.modifier.vba
 '     ^^^^^^^^ storage.modifier.vba
+Erase xArray
+' <----- storage.modifier.vba
 
 Dim str As String
 str = "Hello"
 '     ^^^^^^^ string.quoted.double
+
+c = 1 Xor 1
+'     ^^^ keyword.control.vba
+c = 1 Eqv 1
+'     ^^^ keyword.control.vba
+c = 1 Imp 1
+'     ^^^ keyword.control.vba
+c = "A" Like "A*"
+'       ^^^^ keyword.control.vba
+
+If TypeOf w Is Object  Then
+'  ^^^^^^ keyword.control.vba
+Call Method1(AddressOf Method2)
+'            ^^^^^^^^^ keyword.control.vba
+
+Exit Function
+' <------------- keyword.control.vba
+Exit Property
+' <------------- keyword.control.vba
+Exit Sub
+' <-------- keyword.control.vba
+End
+' <--- keyword.control.vba
+   End
+'  ^^^ keyword.control.vba
+
+Declare PtrSafe Sub First Lib "MyLib" (ByRef a As Any)
+'<------- keyword.other.vba
+'       ^^^^^^^ keyword.other.vba
+'                                                 ^^^ support.type.builtin
+
+Private WithEvents app As Outlook.Application
+'       ^^^^^^^^^^ keyword.other.vba
+
+Event LogonCompleted(UserName as String) 
+' <----- keyword.other.vba
+ 
+Sub Logon 
+    RaiseEvent LogonCompleted ("AntoineJan") 
+'   ^^^^^^^^^^ keyword.other.vba
+End Sub

--- a/syntaxes/tests/procedure.bas
+++ b/syntaxes/tests/procedure.bas
@@ -1,5 +1,10 @@
 ' SYNTAX TEST "source.vba" "Sub, Function and anything related"
 
+Type CustomType
+' <---- keyword.other.vba
+End Type
+' <-------- keyword.other.vba
+
 Private Sub doStuff(ByRef x As String)
 ' <------- keyword.other.visibility.vba
 '       ^^^ keyword.other.vba

--- a/syntaxes/vba.tmGrammar.yml
+++ b/syntaxes/vba.tmGrammar.yml
@@ -2,6 +2,7 @@
 # Copyright (c) 2021-2022 Lukas Neubert
 # Use of this source file is governed by the MIT license.
 
+name: Visual Basic for Applications
 scopeName: source.vba
 fileTypes:
   - .bas
@@ -34,9 +35,9 @@ repository:
       - name: keyword.conditional.end.vba
         match: (?i:\b(End( )?If|End (Select|With)|Next|Wend|Loop(( While)|( Until))?|Exit (For|Do|While))\b)
       - name: keyword.control.vba
-        match: (?i:\b((?<= )E(nd|xit)|As|And|By(Ref|Val)|Goto|Is|Like|Mod|Not|On Error|Optional|Or|Resume Next|Stop|Xor)\b)
+        match: (?i:(\b(Exit (Function|Property|Sub)|As|And|By(Ref|Val)|Goto|Is|Like|Mod|Not|On Error|Optional|Or|Resume Next|Stop|Xor|Eqv|Imp|TypeOf|AddressOf)\b)|(\b(End)\b(?=\n)))
       - name: keyword.other.vba
-        match: (?i:\b(Attribute|Call|End (Function|Property|Sub)|(Static )?(Const|Function|Property|Sub))\b)
+        match: (?i:\b(Attribute|Call|End (Function|Property|Sub|Type)|(Static )?(Const|Function|Property|Sub|Type)|Declare|PtrSafe|WithEvents|Event|RaiseEvent)\b)
       - name: keyword.other.visibility.vba
         match: (?i:\b(Private|Public|Friend)\b)
       - name: constant.language.vba
@@ -60,7 +61,7 @@ repository:
   storage:
     patterns:
       - name: storage.modifier.vba
-        match: (?i)\b(Class|Const|Dim|(G|L|S)et|ReDim( Preserve)?)\b
+        match: (?i)\b(Class|Const|Dim|(G|L|S)et|ReDim( Preserve)?|Erase)\b
 
   strings:
     name: string.quoted.double
@@ -70,7 +71,7 @@ repository:
   types:
     patterns:
       - name: support.type.builtin
-        match: (?i)\b(Byte|Boolean|Currency|Collection|Date|Double|Integer|Long(Long|Ptr)?|Object|Single|String)|Variant\b
+        match: (?i)\b(Any|Byte|Boolean|Currency|Collection|Date|Double|Integer|Long(Long|Ptr)?|Object|Single|String)|Variant\b
       - match: (?i)(?<=As\s+)([a-zA-Z]+)
         captures:
           1:


### PR DESCRIPTION
Add some missing keywords.

Fix "Exit Function" and "End" when there was tab before the keyword.