### PR TITLE
Add `Rem` statement support + tests

### DIFF
--- a/syntaxes/tests/vba/comments.bas
+++ b/syntaxes/tests/vba/comments.bas
@@ -1,0 +1,41 @@
+' SYNTAX TEST "source.vba" "test comment variations"
+
+  ' Some comment
+' ^^^^^^^^^^^^^^ comment.line.quote
+
+10 ' Some comment with line number
+'^ constant.numeric.decimal
+'  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
+
+Label1: ' Some comment with label
+'       ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
+
+Dim x as Long 'Some comment at the end of a line
+'             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
+
+Dim x As Long: 'Test comment with colon
+'              ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
+
+  Rem Some comment
+' ^^^^^^^^^^^^^^^^ comment.line.rem
+
+10 Rem Some comment with line number
+'^ constant.numeric.decimal
+'  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
+
+Label1: Rem Some comment with label
+'       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
+
+Dim x as Long Rem Some comment at the end of a line
+'             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - comment.line.rem
+
+Dim x As Long: Rem Test comment with colon
+'              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
+
+' multi line _
+  comment
+' ^^^^^^^ comment.line.continuation
+
+Rem multi line _
+  comment
+' ^^^^^^^ comment.line.continuation

--- a/syntaxes/tests/vba/comments.bas
+++ b/syntaxes/tests/vba/comments.bas
@@ -4,7 +4,7 @@
 ' ^^^^^^^^^^^^^^ comment.line.quote
 
 10 ' Some comment with line number
-'^ constant.numeric.decimal
+' <-- constant.numeric.decimal
 '  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
 
 Label1: ' Some comment with label
@@ -20,7 +20,7 @@ Dim x As Long: 'Test comment with colon
 ' ^^^^^^^^^^^^^^^^ comment.line.rem
 
 10 Rem Some comment with line number
-'^ constant.numeric.decimal
+' <-- constant.numeric.decimal
 '  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
 
 Label1: Rem Some comment with label

--- a/syntaxes/tests/vba/comments.bas
+++ b/syntaxes/tests/vba/comments.bas
@@ -39,3 +39,4 @@ Dim x As Long: Rem Test comment with colon
 Rem multi line _
   comment
 ' ^^^^^^^ comment.line.continuation
+  

--- a/syntaxes/tests/vba/other.bas
+++ b/syntaxes/tests/vba/other.bas
@@ -35,6 +35,14 @@ Dim x as Long Rem Some comment at the end of a line
 Dim x As Long: Rem Test comment with colon
 '              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
 
+' multi line _
+  comment
+' ^^^^^^^ comment.line.continuation
+
+Rem multi line _
+  comment
+' ^^^^^^^ comment.line.continuation
+
 Public Const FOO As Integer = 1
 '      ^^^^^ keyword.other.vba
 '                ^^ keyword.control.vba

--- a/syntaxes/tests/vba/other.bas
+++ b/syntaxes/tests/vba/other.bas
@@ -10,8 +10,8 @@ Attribute VB_Name = "SyntaxTest"
 '^ constant.numeric.decimal
 '  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
 
-Label1 ' Some comment with label
-'      ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
+Label1: ' Some comment with label
+'       ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
 
 Dim x as Long 'Some comment at the end of a line
 '             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
@@ -26,8 +26,8 @@ Dim x As Long: 'Test comment with colon
 '^ constant.numeric.decimal
 '  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
 
-Label1 Rem Some comment with label
-'      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
+Label1: Rem Some comment with label
+'       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
 
 Dim x as Long Rem Some comment at the end of a line
 '             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - comment.line.rem

--- a/syntaxes/tests/vba/other.bas
+++ b/syntaxes/tests/vba/other.bas
@@ -7,7 +7,7 @@ Attribute VB_Name = "SyntaxTest"
 ' ^^^^^^^^^^^^^^ comment.line.quote
 
  10 ' Some comment with line number
-'<--- constant.numeric.decimal
+'^^ constant.numeric.decimal
 '   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
 
  Label1 ' Some comment with label
@@ -20,10 +20,10 @@ Dim x As Long: 'Test comment with colon
 '              ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
 
   Rem Some comment
-' ^^^^^^^^^^^^^^^^ comment.line.quote
+' ^^^^^^^^^^^^^^^^ comment.line.rem
 
  10 Rem Some comment with line number
-'<--- constant.numeric.decimal
+'^^ constant.numeric.decimal
 '   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
 
  Label1 Rem Some comment with label

--- a/syntaxes/tests/vba/other.bas
+++ b/syntaxes/tests/vba/other.bas
@@ -6,12 +6,12 @@ Attribute VB_Name = "SyntaxTest"
   ' Some comment
 ' ^^^^^^^^^^^^^^ comment.line.quote
 
- 10 ' Some comment with line number
-'^^ constant.numeric.decimal
-'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
+10 ' Some comment with line number
+'^ constant.numeric.decimal
+'  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
 
- Label1 ' Some comment with label
-'       ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
+Label1 ' Some comment with label
+'      ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
 
 Dim x as Long 'Some comment at the end of a line
 '             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
@@ -22,12 +22,12 @@ Dim x As Long: 'Test comment with colon
   Rem Some comment
 ' ^^^^^^^^^^^^^^^^ comment.line.rem
 
- 10 Rem Some comment with line number
-'^^ constant.numeric.decimal
-'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
+10 Rem Some comment with line number
+'^ constant.numeric.decimal
+'  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
 
- Label1 Rem Some comment with label
-'       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
+Label1 Rem Some comment with label
+'      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
 
 Dim x as Long Rem Some comment at the end of a line
 '             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - comment.line.rem

--- a/syntaxes/tests/vba/other.bas
+++ b/syntaxes/tests/vba/other.bas
@@ -6,6 +6,35 @@ Attribute VB_Name = "SyntaxTest"
   ' Some comment
 ' ^^^^^^^^^^^^^^ comment.line.quote
 
+ 10 ' Some comment with line number
+'<--- constant.numeric.decimal
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
+
+ Label1 ' Some comment with label
+'       ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
+
+Dim x as Long 'Some comment at the end of a line
+'             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
+
+Dim x As Long: 'Test comment with colon
+'              ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
+
+  Rem Some comment
+' ^^^^^^^^^^^^^^^^ comment.line.quote
+
+ 10 Rem Some comment with line number
+'<--- constant.numeric.decimal
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
+
+ Label1 Rem Some comment with label
+'       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
+
+Dim x as Long Rem Some comment at the end of a line
+'             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - comment.line.rem
+
+Dim x As Long: Rem Test comment with colon
+'              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
+
 Public Const FOO As Integer = 1
 '      ^^^^^ keyword.other.vba
 '                ^^ keyword.control.vba

--- a/syntaxes/tests/vba/other.bas
+++ b/syntaxes/tests/vba/other.bas
@@ -3,46 +3,6 @@
 Attribute VB_Name = "SyntaxTest"
 ' <--------- keyword.other.vba
 
-  ' Some comment
-' ^^^^^^^^^^^^^^ comment.line.quote
-
-10 ' Some comment with line number
-'^ constant.numeric.decimal
-'  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
-
-Label1: ' Some comment with label
-'       ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
-
-Dim x as Long 'Some comment at the end of a line
-'             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
-
-Dim x As Long: 'Test comment with colon
-'              ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.quote
-
-  Rem Some comment
-' ^^^^^^^^^^^^^^^^ comment.line.rem
-
-10 Rem Some comment with line number
-'^ constant.numeric.decimal
-'  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
-
-Label1: Rem Some comment with label
-'       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
-
-Dim x as Long Rem Some comment at the end of a line
-'             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - comment.line.rem
-
-Dim x As Long: Rem Test comment with colon
-'              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem
-
-' multi line _
-  comment
-' ^^^^^^^ comment.line.continuation
-
-Rem multi line _
-  comment
-' ^^^^^^^ comment.line.continuation
-
 Public Const FOO As Integer = 1
 '      ^^^^^ keyword.other.vba
 '                ^^ keyword.control.vba

--- a/syntaxes/vba.tmGrammar.yml
+++ b/syntaxes/vba.tmGrammar.yml
@@ -22,8 +22,7 @@ patterns:
 
 repository:
   comments:
-    begin: "(?=')|(?:^(?:|(\d*)\s*|[a-zA-Z][a-zA-Z0-9]{0,254}:\s*)|:\s*)(?=(?i:Rem
-      ))"
+    begin: "(?=')|(?:^(?:|(\d*)\s*|[a-zA-Z][a-zA-Z0-9]{0,254}:\s*)|:\s*)(?=(?i:Rem))"
     beginCaptures:
       '1':
         name: constant.numeric.decimal

--- a/syntaxes/vba.tmGrammar.yml
+++ b/syntaxes/vba.tmGrammar.yml
@@ -22,7 +22,7 @@ patterns:
 
 repository:
   comments:
-    begin: "(?=')|(?:^(?:|(\d*)\s*|[a-zA-Z][a-zA-Z0-9]{0,254}:\s*)|:\s*)(?=(?i:Rem))"
+    begin: "(?=')|(?:^(?:|(\d*)\s*|[a-zA-Z][a-zA-Z0-9]{0,254}:\s*)|:\s*)(?=(?i:Rem ))"
     beginCaptures:
       '1':
         name: constant.numeric.decimal

--- a/syntaxes/vba.tmGrammar.yml
+++ b/syntaxes/vba.tmGrammar.yml
@@ -22,9 +22,19 @@ patterns:
 
 repository:
   comments:
-    name: comment.line.quote
-    begin: "'"
-    end: $
+    begin: "(?=')|(?:^(?:|(\d*)\s*|[a-zA-Z][a-zA-Z0-9]{0,254}:\s*)|:\s*)(?=(?i:Rem
+      ))"
+    beginCaptures:
+      '1':
+        name: constant.numeric.decimal
+    end: "(?<!\s_)$\n"
+    patterns:
+    - name: comment.line.quote
+      match: "'.*"
+    - name: comment.line.rem
+      match: Rem .*
+    - name: comment.line.continuation
+      match: "^.*"
 
   keywords:
     patterns:

--- a/syntaxes/vba.tmGrammar.yml
+++ b/syntaxes/vba.tmGrammar.yml
@@ -22,11 +22,11 @@ patterns:
 
 repository:
   comments:
-    begin: "(?=')|(?:^(?:|(\d*)\s*|[a-zA-Z][a-zA-Z0-9]{0,254}:\s*)|:\s*)(?=(?i:Rem ))"
+    begin: "(?=')|(?:^(?:|(\\d*)\\s*|[a-zA-Z][a-zA-Z0-9]{0,254}:\\s*)|:\\s*)(?=(?i:Rem ))"
     beginCaptures:
       '1':
         name: constant.numeric.decimal
-    end: "(?<!\s_)$\n"
+    end: "(?<!\\s_)$\n"
     patterns:
     - name: comment.line.quote
       match: "'.*"


### PR DESCRIPTION
This PR improves the support for comments highlighting and especially support for the `Rem` statement (close #81). 

The complexity of the `begin` regex is due to the fact that `Rem` statements cannot appear after a valid VBA statement. It must be the first statement on the line, but we need to distinguish line numbers and labels from actual statements in order to implement this restriction.
```
begin: "(?=')|(?:^(?:|(\d*)\s*|[a-zA-Z][a-zA-Z0-9]{0,254}:\s*)|:\s*)(?=(?i:Rem))"
```

We could also replace `{0,254}` with `*` since I doubt someone would use a label longer than 255 characters, but it's technically a limitation in VBA, hence I thought of adding it.

Note as well that using lookahead for `'` and `Rem` allows us to make sure that this piece of text will be available to match in the patterns after.

Regarding the multi-line comment support, it comes from the use of `(?<!\s_)$\n` for the `end` pattern since it allows us to stop only when there is no line continuation. It worked when I edited the grammar on my computer and refreshed VS Code, but I'm not sure how to unit test this with the current setup. I can always remove that part of the PR and just keep the Rem one-line comment support if that's a problem.