### PR TITLE
Add `.vba` as a supported extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
 				"extensions": [
 					".bas",
 					".cls",
-					".frm"
+					".frm",
+					".vba"
 				],
 				"configuration": "./out/language-configuration.json"
 			},

--- a/syntaxes/vba.tmGrammar.yml
+++ b/syntaxes/vba.tmGrammar.yml
@@ -8,6 +8,7 @@ fileTypes:
   - .bas
   - .cls
   - .frm
+  - .vba
 
 patterns:
   - include: "#comments"


### PR DESCRIPTION
`.vba` is an extension associated to VBA by Linguist ([source](https://github.com/github-linguist/linguist/blob/e855ef2b6f90c34074061a2e17acbe853e61b483/lib/linguist/languages.yml#L7206)) and there is currently [2.9k files](https://github.com/search?q=path%3A*.vba+language%3AVBA&type=code) using that extension on GitHub. It's also a popular extension for VBA code in the infosec community, so it would be nice to support it in vscode.