### PR TITLE
Allow custom types with underscore and numbers

### DIFF
--- a/syntaxes/tests/vba/types.bas
+++ b/syntaxes/tests/vba/types.bas
@@ -32,13 +32,23 @@ Dim v as Variant
 Dim spam as MyVarType
 '           ^^^^^^^^^ support.type
 
-Sub eggs(p As ParamType) as RetType
-'             ^^^^^^^^^ support.type
-'                           ^^^^^^^^ support.type
+Dim rm As REMOTE_MEMORY2
+'         ^^^^^^^^^^^^^^ support.type
+
+Function eggs(p As ParamType) as RetType
+'                  ^^^^^^^^^ support.type
+'                                ^^^^^^^ support.type
+End Sub
+
+Sub InitRemoteMemory(ByRef rm As REMOTE_MEMORY2)
+'                                ^^^^^^^^^^^^^^ support.type
 End Sub
 
 Dim myConverter As DateConverter
 '                  ^^^^ - support.type.builtin.vba
+
+Dim se As String_Extension2
+'         ^^^^^^ - support.type.builtin.vba
 
 ConvertAs myVar, myConverter
 '         ^^^^^ - support.type

--- a/syntaxes/vba.tmGrammar.yml
+++ b/syntaxes/vba.tmGrammar.yml
@@ -82,7 +82,7 @@ repository:
     patterns:
       - name: support.type.builtin.vba
         match: (?i)\b(Any|Byte|Boolean|Currency|Collection|Date|Double|Integer|Long(Long|Ptr)?|Object|Single|String|Variant)\b
-      - match: (?i)(?<= As )([a-zA-Z]+)
+      - match: (?i)(?<= As )([a-zA-Z0-9_])
         captures:
           1:
             name: support.type

--- a/syntaxes/vba.tmGrammar.yml
+++ b/syntaxes/vba.tmGrammar.yml
@@ -82,7 +82,7 @@ repository:
     patterns:
       - name: support.type.builtin.vba
         match: (?i)\b(Any|Byte|Boolean|Currency|Collection|Date|Double|Integer|Long(Long|Ptr)?|Object|Single|String|Variant)\b
-      - match: (?i)(?<= As )([a-zA-Z0-9_])
+      - match: (?i)(?<= As )([a-zA-Z][a-zA-Z0-9_]*)
         captures:
           1:
             name: support.type


### PR DESCRIPTION
In the VBA syntax, while all the builtin types only contain letters, user defined types can contain underscores and numbers. Eg.:
```vba
Public Type REMOTE_MEMORY2
    '...
End Type
```
is a valid name for a user defined type.


Hence, types should be allowed to contain these characters and be highlighted properly:

```vba
Public Sub InitRemoteMemory(ByRef rm As REMOTE_MEMORY2)
    '...
End Sub
```
Example in the wild: https://github.com/cristianbuse/VBA-MemoryTools/blob/922a64c48e7e6c276c7be64605216173cc8bf7d9/src/LibMemory.bas#L642


For the tests, I'm not sure if the one with `String_Extension2` is needed. Also note that I've changed `Sub eggs...` to `Function eggs...` because it has a return type.