### PR TITLE
Add extra tests for metadata keywords

### DIFF
--- a/syntaxes/tests/vba/metadata.bas
+++ b/syntaxes/tests/vba/metadata.bas
@@ -12,10 +12,20 @@ END
  End
 '^^^ keyword.control.vba
 
-Sub test()
+Sub Begin(ByVal MyString As String)
 
     MsgBox "test"
     End
    '^^^ keyword.control.vba
+
+End Sub
+
+Sub OtherSub()
+
+    Begin MyString:="test"
+   '^^^^^ - keyword.metadata.vba
+
+    End
+   '^^^ - keyword.metadata.vba
 
 End Sub

--- a/syntaxes/tests/vba/metadata.bas
+++ b/syntaxes/tests/vba/metadata.bas
@@ -13,6 +13,7 @@ END
 '^^^ keyword.control.vba
 
 Sub Begin(ByVal MyString As String)
+   '^^^^^ - keyword.metadata.vba
 
     MsgBox "test"
     End


### PR DESCRIPTION
These additionnal tests are there to make sure there is no confusion with the `BEGIN` and `END` keyword when they appear inside a actual code.