### PR TITLE
Remove Width as a keyword

### DIFF
--- a/syntaxes/vba.tmGrammar.yml
+++ b/syntaxes/vba.tmGrammar.yml
@@ -46,7 +46,7 @@ repository:
       - name: keyword.control.vba
         match: (?i:(\b(Exit (Function|Property|Sub)|As|And|By(Ref|Val)|Goto|Is|Like|Mod|Not|On Error|Optional|Or|Resume Next|Stop|Xor|Eqv|Imp|TypeOf|AddressOf)\b)|(\b(End)\b(?=\n)))
       - name: keyword.io.vba
-        match: (?i:\b(Open|Close|Line Input|Lock|Unlock|Print|Seek|Width|Get|Put|Write)\b)
+        match: (?i:\b(Open|Close|Line Input|Lock|Unlock|Print|Seek|Get|Put|Write)\b)
       - name: keyword.io.vba
         match: "(?i:\\b(Input)(?= #))"
       - name: keyword.other.vba


### PR DESCRIPTION
I wanted to double check that all the IO keywords that were introduced were reserved keywords and could not be confused with variables.

Turns out it's the case for all of them except `Width`:

![image](https://github.com/serkonda7/vscode-vba/assets/31558169/2815129b-1fdd-43ae-83a6-11bfe189c84f)


Then, I went and look at the [documentation](https://learn.microsoft.com/en-us/office/vba/language/reference/user-interface-help/widthstatement) and noticed that the `Width` statement is not a real statement, it's more of Sub and the VBA object explorer confirms this:

![image](https://github.com/serkonda7/vscode-vba/assets/31558169/871bc956-be47-476b-a9c3-87792d3390e5)

I would then suggest to remove it from the list as it's not even highlighted in the VBE itself.

Related issue: https://github.com/serkonda7/vscode-vba/issues/96
