### PR TITLE
Add `.doccls` as a supported extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 				"extensions": [
 					".bas",
 					".cls",
+					".doccls",
 					".frm",
 					".vba"
 				],

--- a/syntaxes/vba.tmGrammar.yml
+++ b/syntaxes/vba.tmGrammar.yml
@@ -6,6 +6,7 @@ scopeName: source.vba
 fileTypes:
   - .bas
   - .cls
+  - .doccls
   - .frm
   - .vba
 


### PR DESCRIPTION
Per https://github.com/rubberduck-vba/Rubberduck/issues/2109, Rubberduck VBA uses the .doccls extension for document modules tied to a spreadsheet.

PR add support for syntax highlighting with the .doccls extension.

Close #103 