### PR TITLE
add `xlam` and `ppam` file extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"activationEvents": [
 		"onLanguage:vba",
 		"onLanguage:wwb",
-		"workspaceContains:**/*.{docm,xlsm,pptm}"
+		"workspaceContains:**/*.{docm,xlsm,pptm,xlam,ppam}"
 	],
 	"main": "./out/extension.js",
 	"capabilities": {

--- a/src/extension.js.bt
+++ b/src/extension.js.bt
@@ -9,7 +9,7 @@ import 'vscode' as #JS.vscode
 
 @export('activate')
 fun activate(context #JS.Any) {
-	#JS.'JS.vscode.commands.executeCommand("setContext", "vba.ctx.docExts", [".docm", ".xlsm", ".pptm"])'
+	#JS.'JS.vscode.commands.executeCommand("setContext", "vba.ctx.docExts", [".docm", ".xlsm", ".pptm", ".xlam", ".ppam"])'
 
 	#JS.'context.subscriptions.push(JS.vscode.commands.registerCommand("vba.extract_from_doc", extension__extract_from_doc))'
 	#JS.'context.subscriptions.push(JS.vscode.commands.registerCommand("vba.write_to_doc", extension__write_to_doc))'


### PR DESCRIPTION
The title says it all. Add Add-In extensions as well to activation events, i.e. `xlam` and `ppam` extensions.