### PR TITLE
Add support for "Global" keyword

### DIFF
--- a/syntaxes/tests/vba/visibilityKeywords.bas
+++ b/syntaxes/tests/vba/visibilityKeywords.bas
@@ -3,6 +3,9 @@
 Public strName As String
 ' <------ keyword.other.visibility.vba
 
+Global strName As String
+' <------ keyword.other.visibility.vba
+
 Private strMsg As String
 ' <------- keyword.other.visibility.vba
 

--- a/syntaxes/vba.yaml-tmlanguage
+++ b/syntaxes/vba.yaml-tmlanguage
@@ -59,7 +59,7 @@ repository:
       - name: keyword.other.option.vba
         match: (?i)\bOption (Base [01]|Compare (Binary|Text)|Explicit|Private Module)\b
       - name: keyword.other.visibility.vba
-        match: (?i:\b(Private|Public|Friend)\b)
+        match: (?i:\b(Private|Public|Global|Friend)\b)
       - name: constant.language.vba
         match: (?i)\b(Empty|False|Nothing|Null|True)\b
 


### PR DESCRIPTION
This keyword is in VBA for backwards compatibility. Not mentioned in the docs, but appears in the [specs](https://learn.microsoft.com/en-us/openspecs/microsoft_general_purpose_programming_languages/ms-vbal/0f9113df-fd9c-485a-9583-fdb0e9d68e1b).

`Global` appears in roughly in [4k files](https://github.com/search?q=path%3A*.bas%20%2F%5EGlobal%2F&type=code) on GitHub. 