### PR TITLE
Remove lookbehind for `functions` scope

### DIFF
--- a/syntaxes/tests/vba/other.bas
+++ b/syntaxes/tests/vba/other.bas
@@ -136,7 +136,7 @@ Private WithEvents app As Outlook.Application
 Event LogonCompleted(UserName as String)
 ' <----- keyword.other.vba
 
-Sub Logon
+Sub Logon()
     RaiseEvent LogonCompleted ("AntoineJan")
 '   ^^^^^^^^^^ keyword.other.vba
 End Sub

--- a/syntaxes/tests/vba/procedure.bas
+++ b/syntaxes/tests/vba/procedure.bas
@@ -50,3 +50,7 @@ End Function
 Call mSub()
 ' <---- keyword.other.vba
 '    ^^^^ entity.name.function.vba
+
+Call SubWithNoArgs
+' <---- keyword.other.vba
+'    ^^^^^^^^^^^^^ entity.name.function.vba

--- a/syntaxes/vba.yaml-tmlanguage
+++ b/syntaxes/vba.yaml-tmlanguage
@@ -47,7 +47,7 @@ repository:
     patterns:
       - name: entity.name.function.vba
         match: (?i:\b([a-zA-Z][a-zA-Z0-9_]*)\b)
-    end: \(
+    end: \(|(?=\n)
     
   keywords:
     patterns:

--- a/syntaxes/vba.yaml-tmlanguage
+++ b/syntaxes/vba.yaml-tmlanguage
@@ -39,9 +39,16 @@ repository:
       match: ^.*
 
   functions:
-    name: entity.name.function.vba
-    match: (?i:\b(?:(?<=(Call|Function|Sub) ))([a-zA-Z][a-zA-Z0-9_]*)\b)(?=\(\)?)
-
+    name: testing.vba
+    begin: (?i:\b(Call|Function|Sub) )
+    beginCaptures:
+        1:
+          name: keyword.other.vba
+    patterns:
+      - name: entity.name.function.vba
+        match: (?i:\b([a-zA-Z][a-zA-Z0-9_]*)\b)
+    end: \(
+    
   keywords:
     patterns:
       - name: keyword.conditional.vba


### PR DESCRIPTION
Fixes https://github.com/serkonda7/vscode-vba/issues/118

Note that I've also added a test to account for cases where `Call` is used for a sub without brackets.

