### PR TITLE
Remove debugging scope name

### DIFF
--- a/syntaxes/vba.yaml-tmlanguage
+++ b/syntaxes/vba.yaml-tmlanguage
@@ -41,7 +41,7 @@ repository:
   functions:
     begin: (?i:\b(Call|Function|Sub) )
     beginCaptures:
-        1:
+        '1':
           name: keyword.other.vba
     patterns:
       - name: entity.name.function.vba

--- a/syntaxes/vba.yaml-tmlanguage
+++ b/syntaxes/vba.yaml-tmlanguage
@@ -39,7 +39,6 @@ repository:
       match: ^.*
 
   functions:
-    name: testing.vba
     begin: (?i:\b(Call|Function|Sub) )
     beginCaptures:
         1:


### PR DESCRIPTION
Remove scope name used for debugging while testing https://github.com/serkonda7/vscode-vba/pull/119
This shouldn't affect the user experience anyway, but keeps things clean.