### PR TITLE
Add DefType keywords

### DIFF
--- a/syntaxes/tests/vba/other.bas
+++ b/syntaxes/tests/vba/other.bas
@@ -1,5 +1,8 @@
 ' SYNTAX TEST "source.vba" "main syntax test"
 
+DefInt A-Z
+' <------ keyword.other.deftype.vba
+
 Attribute VB_Name = "SyntaxTest"
 ' <--------- keyword.other.vba
 

--- a/syntaxes/vba.yaml-tmlanguage
+++ b/syntaxes/vba.yaml-tmlanguage
@@ -64,6 +64,8 @@ repository:
         match: (?i:\b(Attribute|Call|End (Function|Property|Sub|Type|Enum)|(Const|Function|Property|Sub|Type|Enum)|Declare|PtrSafe|WithEvents|Event|RaiseEvent|Implements)\b)
       - name: keyword.other.option.vba
         match: (?i)\bOption (Base [01]|Compare (Binary|Text)|Explicit|Private Module)\b
+      - name: keyword.other.deftype.vba
+        match: (?i)\b(DefBool|DefByte|DefInt|DefLng|DefLngLng|DefLngPtr|DefCur|DefSng|DefDbl|DefDec|DefDate|DefStr|DefObj|DefVar)\b
       - name: keyword.other.visibility.vba
         match: (?i:\b(Private|Public|Global|Friend)\b)
       - name: constant.language.vba


### PR DESCRIPTION
DefType keywords are reserved keywords used at the [module level](https://learn.microsoft.com/en-us/office/vba/language/glossary/vbe-glossary#module-level) to set the default [data type](https://learn.microsoft.com/en-us/office/vba/language/reference/user-interface-help/data-type-summary) for [variables](https://learn.microsoft.com/en-us/office/vba/language/glossary/vbe-glossary#variable), [arguments](https://learn.microsoft.com/en-us/office/vba/language/glossary/vbe-glossary#argument) passed to [procedures](https://learn.microsoft.com/en-us/office/vba/language/glossary/vbe-glossary#procedure), and the return type for [Function](https://learn.microsoft.com/en-us/office/vba/language/reference/user-interface-help/function-statement) and [Property Get](https://learn.microsoft.com/en-us/office/vba/language/reference/user-interface-help/property-get-statement) procedures whose names start with the specified characters.

[Source](https://learn.microsoft.com/en-us/office/vba/language/concepts/getting-started/deftype-statements)

Example of use in the wild: https://github.com/gaouservbf/EveryDiscord/blob/67bb2fdec911f084db59e3f03bedc943b16b44c1/src/mdTlsSodium.bas#L13