### PR TITLE
Add `Option Compare Database` as a valid VBA statement

### DIFF
--- a/syntaxes/tests/vba/option.bas
+++ b/syntaxes/tests/vba/option.bas
@@ -9,6 +9,8 @@
 ' ^^^^^^^^^^^^^^^^^^^^^ keyword.other.option.vba
   Option Compare Text
 ' ^^^^^^^^^^^^^^^^^^^ keyword.other.option.vba
+  Option Compare Database
+' ^^^^^^^^^^^^^^^^^^^^^^^ keyword.other.option.vba
 
   Option Explicit
 ' ^^^^^^^^^^^^^^^ keyword.other.option.vba

--- a/syntaxes/vba.yaml-tmlanguage
+++ b/syntaxes/vba.yaml-tmlanguage
@@ -63,7 +63,7 @@ repository:
       - name: keyword.other.vba
         match: (?i:\b(Attribute|Call|End (Function|Property|Sub|Type|Enum)|(Const|Function|Property|Sub|Type|Enum)|Declare|PtrSafe|WithEvents|Event|RaiseEvent|Implements)\b)
       - name: keyword.other.option.vba
-        match: (?i)\bOption (Base [01]|Compare (Binary|Text)|Explicit|Private Module)\b
+        match: (?i)\bOption (Base [01]|Compare (Binary|Text|Database)|Explicit|Private Module)\b
       - name: keyword.other.deftype.vba
         match: (?i)\b(DefBool|DefByte|DefInt|DefLng|DefLngLng|DefLngPtr|DefCur|DefSng|DefDbl|DefDec|DefDate|DefStr|DefObj|DefVar)\b
       - name: keyword.other.visibility.vba


### PR DESCRIPTION
The `Option Compare Database` statement is valid in Access and should be included in the grammar:

> Option Compare Database can only be used within Microsoft Access. This results in string comparisons based on the sort order determined by the locale ID of the database where the string comparisons occur.

From the [docs](https://learn.microsoft.com/en-us/office/vba/language/reference/user-interface-help/option-compare-statement)
